### PR TITLE
Get grid lines drawing properly

### DIFF
--- a/src/Eto.VeldridSurface/VeldridSurface.cs
+++ b/src/Eto.VeldridSurface/VeldridSurface.cs
@@ -450,7 +450,7 @@ namespace PlaceholderName
 		{
 			Swapchain?.Resize((uint)e.Width, (uint)e.Height);
 
-			Properties.TriggerEvent(ResizeEvent, this, e);
+			Properties.TriggerEvent(ResizeEvent, this, EventArgs.Empty);
 		}
 
 		protected override void OnSizeChanged(EventArgs e)

--- a/src/shaders/VertexColor-vertex.450.glsl
+++ b/src/shaders/VertexColor-vertex.450.glsl
@@ -1,18 +1,23 @@
 #version 450
 
-layout (location = 0) in vec2 Position;
+layout (location = 0) in vec3 Position;
 layout (location = 1) in vec4 Color;
 
 layout (location = 0) out vec4 fsin_Color;
 
-layout (set = 0, binding = 0) uniform ModelMatrix
+layout (set = 0, binding = 0) uniform ViewMatrix
+{
+	mat4 view;
+};
+
+layout (set = 1, binding = 0) uniform ModelMatrix
 {
 	mat4 model;
 };
 
 void main()
 {
-	gl_Position = model * vec4(Position, 0, 1);
+	gl_Position = view * model * vec4(Position, 1);
 
 	fsin_Color = Color;
 }


### PR DESCRIPTION
Sorting out how to open a PR on a fork of my own project was a bit of an odyssey, but I think I've got it now.

Seems like there were a few issues preventing the grid from drawing correctly:

- You updated the Veldrid code to use Vector3 vertex coordinates, but didn't update the shader itself to use the vec3 data type for the input vertex attribute 'Position'.

- The gridIndices field was defined as an array of uints instead of ushorts.

- GridIndexBuffer was too big, though honestly I'm not sure if that's a problem the way "too small" would be.

- The vertex and index buffer creation and updating only happened once, even though window size changes necessitate more or fewer vertices/indices. I've moved those steps to the drawGrid method to compensate.

- The grid line vertex coordinates were stored in screen space, so I've added a view matrix to transform them to view space in the shader.

- I've also attached a little event handler to redraw the grid when the window gets resized. It still seems a little wonky when the window gets very narrow, but I didn't have time to dig into the details of that.

I suspect a couple of those are unrelated to the grid not drawing at all, but the issues came up as I was poking around, so I thought they were worth addressing while I was at it.

Hope this helps! Still messing around with [the XamMac stuff I mentioned](https://github.com/ItEndsWithTens/Eto.Veldrid/issues/2#issuecomment-496037213), but I'm sure I'll get there one day.