### PR TITLE
Fix drawing in high DPI environments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,7 +60,7 @@ dotnet_style_null_propagation = true
 
 indent_style = tab
 
-[*.{csproj,props,targets}]
+[*.{csproj,props,targets,manifest}]
 
 indent_style = space
 indent_size = 2

--- a/src/Eto.VeldridSurface/Eto.VeldridSurface.csproj
+++ b/src/Eto.VeldridSurface/Eto.VeldridSurface.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0-ci-10199" />
+    <PackageReference Include="Eto.Forms" Version="2.5.0-rc.4" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
     <PackageReference Include="Unofficial.LibTessDotNet" Version="2.0.2" />
     <PackageReference Include="Veldrid" Version="4.7.0" />

--- a/src/Eto.VeldridSurface/VeldridDriver.cs
+++ b/src/Eto.VeldridSurface/VeldridDriver.cs
@@ -144,8 +144,8 @@ namespace PlaceholderName
 
 		Point WorldToScreen(float x, float y)
 		{
-			return new Point((int)((x - ovpSettings.cameraPosition.X / (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + Surface.Width / 2),
-					(int)((y - ovpSettings.cameraPosition.Y / (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + Surface.Height / 2));
+			return new Point((int)((x - ovpSettings.cameraPosition.X / (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + Surface.RenderWidth / 2),
+					(int)((y - ovpSettings.cameraPosition.Y / (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + Surface.RenderHeight / 2));
 		}
 
 		Point WorldToScreen(PointF pt)
@@ -162,8 +162,8 @@ namespace PlaceholderName
 
 		PointF ScreenToWorld(int x, int y)
 		{
-			return new PointF((float)(x - Surface.Width / 2) * (ovpSettings.zoomFactor * ovpSettings.base_zoom) + ovpSettings.cameraPosition.X,
-					 (float)(y - Surface.Height / 2) * (ovpSettings.zoomFactor * ovpSettings.base_zoom) + ovpSettings.cameraPosition.Y);
+			return new PointF((float)(x - Surface.RenderWidth / 2) * (ovpSettings.zoomFactor * ovpSettings.base_zoom) + ovpSettings.cameraPosition.X,
+					 (float)(y - Surface.RenderHeight / 2) * (ovpSettings.zoomFactor * ovpSettings.base_zoom) + ovpSettings.cameraPosition.Y);
 		}
 
 		PointF ScreenToWorld(Point pt)
@@ -173,8 +173,8 @@ namespace PlaceholderName
 
 		RectangleF getViewPort()
 		{
-			PointF bl = ScreenToWorld(Surface.Location.X - Surface.Width / 2, Surface.Location.Y - Surface.Height / 2);
-			PointF tr = ScreenToWorld(Surface.Location.X + Surface.Width / 2, Surface.Location.Y + Surface.Height / 2);
+			PointF bl = ScreenToWorld(Surface.Location.X - Surface.RenderWidth / 2, Surface.Location.Y - Surface.RenderHeight / 2);
+			PointF tr = ScreenToWorld(Surface.Location.X + Surface.RenderWidth / 2, Surface.Location.Y + Surface.RenderHeight / 2);
 			return new RectangleF(bl.X, bl.Y, tr.X - bl.X, tr.Y - bl.Y);
 		}
 
@@ -646,7 +646,7 @@ namespace PlaceholderName
 				if (WorldToScreen(new SizeF(spacing, 0.0f)).Width >= 4.0f)
 				{
 					int k = 0;
-					for (float i = 0; i > -(Surface.Width * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.X; i -= spacing)
+					for (float i = 0; i > -(Surface.RenderWidth * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.X; i -= spacing)
 					{
 						float r = 0.0f;
 						float g = 0.0f;
@@ -665,11 +665,11 @@ namespace PlaceholderName
 							k = 0;
 						}
 						k++;
-						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.Height, gridZ), new RgbaFloat(r, g, b, 1.0f)));
-						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.Height, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.RenderHeight, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.RenderHeight, gridZ), new RgbaFloat(r, g, b, 1.0f)));
 					}
 					k = 0;
-					for (float i = 0; i < (Surface.Width * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.X; i += spacing)
+					for (float i = 0; i < (Surface.RenderWidth * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.X; i += spacing)
 					{
 						float r = 0.0f;
 						float g = 0.0f;
@@ -688,11 +688,11 @@ namespace PlaceholderName
 							k = 0;
 						}
 						k++;
-						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.Height, gridZ), new RgbaFloat(r, g, b, 1.0f)));
-						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.Height, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.RenderHeight, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(i, ovpSettings.cameraPosition.Y + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.RenderHeight, gridZ), new RgbaFloat(r, g, b, 1.0f)));
 					}
 					k = 0;
-					for (float i = 0; i > -(Surface.Height * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.Y; i -= spacing)
+					for (float i = 0; i > -(Surface.RenderHeight * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.Y; i -= spacing)
 					{
 						float r = 0.0f;
 						float g = 0.0f;
@@ -711,11 +711,11 @@ namespace PlaceholderName
 							k = 0;
 						}
 						k++;
-						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.Width, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
-						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.Width, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.RenderWidth, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.RenderWidth, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
 					}
 					k = 0;
-					for (float i = 0; i < (Surface.Height * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.Y; i += spacing)
+					for (float i = 0; i < (Surface.RenderHeight * (ovpSettings.zoomFactor * ovpSettings.base_zoom)) + ovpSettings.cameraPosition.Y; i += spacing)
 					{
 						float r = 0.0f;
 						float g = 0.0f;
@@ -734,8 +734,8 @@ namespace PlaceholderName
 							k = 0;
 						}
 						k++;
-						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.Width, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
-						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.Width, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * Surface.RenderWidth, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
+						grid.Add(new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + (ovpSettings.zoomFactor * ovpSettings.base_zoom) * -Surface.RenderWidth, i, gridZ), new RgbaFloat(r, g, b, 1.0f)));
 					}
 					gridArray = grid.ToArray();
 					gridIndices = new ushort[gridArray.Length];
@@ -763,10 +763,10 @@ namespace PlaceholderName
 			if (ovpSettings.showAxes)
 			{
 				axesArray = new VertexPositionColor[4];
-				axesArray[0] = new VertexPositionColor(new Vector3(0.0f, ovpSettings.cameraPosition.Y + Surface.Height * (ovpSettings.zoomFactor * ovpSettings.base_zoom), axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
-				axesArray[1] = new VertexPositionColor(new Vector3(0.0f, ovpSettings.cameraPosition.Y - Surface.Height * (ovpSettings.zoomFactor * ovpSettings.base_zoom), axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
-				axesArray[2] = new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + Surface.Width * (ovpSettings.zoomFactor * ovpSettings.base_zoom), 0.0f, axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
-				axesArray[3] = new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X - Surface.Width * (ovpSettings.zoomFactor * ovpSettings.base_zoom), 0.0f, axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
+				axesArray[0] = new VertexPositionColor(new Vector3(0.0f, ovpSettings.cameraPosition.Y + Surface.RenderHeight * (ovpSettings.zoomFactor * ovpSettings.base_zoom), axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
+				axesArray[1] = new VertexPositionColor(new Vector3(0.0f, ovpSettings.cameraPosition.Y - Surface.RenderHeight * (ovpSettings.zoomFactor * ovpSettings.base_zoom), axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
+				axesArray[2] = new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X + Surface.RenderWidth * (ovpSettings.zoomFactor * ovpSettings.base_zoom), 0.0f, axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
+				axesArray[3] = new VertexPositionColor(new Vector3(ovpSettings.cameraPosition.X - Surface.RenderWidth * (ovpSettings.zoomFactor * ovpSettings.base_zoom), 0.0f, axisZ), new RgbaFloat(ovpSettings.axisColor.R, ovpSettings.axisColor.G, ovpSettings.axisColor.B, 1.0f));
 
 				axesIndices = new ushort[4] { 0, 1, 2, 3 };
 
@@ -808,10 +808,10 @@ namespace PlaceholderName
 
 			float zoom = ovpSettings.zoomFactor * ovpSettings.base_zoom;
 
-			float left = ovpSettings.cameraPosition.X - (Surface.Width / 2) * zoom;
-			float right = ovpSettings.cameraPosition.X + (Surface.Width / 2) * zoom;
-			float bottom = ovpSettings.cameraPosition.Y + (Surface.Height / 2) * zoom;
-			float top = ovpSettings.cameraPosition.Y - (Surface.Height / 2) * zoom;
+			float left = ovpSettings.cameraPosition.X - (Surface.RenderWidth / 2) * zoom;
+			float right = ovpSettings.cameraPosition.X + (Surface.RenderWidth / 2) * zoom;
+			float bottom = ovpSettings.cameraPosition.Y + (Surface.RenderHeight / 2) * zoom;
+			float top = ovpSettings.cameraPosition.Y - (Surface.RenderHeight / 2) * zoom;
 
 			ViewMatrix = Matrix4x4.CreateOrthographicOffCenter(left, right, bottom, top, 0.0f, 1.0f);
 			CommandList.UpdateBuffer(ViewBuffer, 0, ViewMatrix);

--- a/src/Eto.VeldridSurface/VeldridSurface.cs
+++ b/src/Eto.VeldridSurface/VeldridSurface.cs
@@ -112,6 +112,9 @@ namespace PlaceholderName
 	{
 		public new interface IHandler : Control.IHandler
 		{
+			int RenderWidth { get; }
+			int RenderHeight { get; }
+
 			void InitializeOpenGL();
 			void InitializeOtherApi();
 		}
@@ -154,6 +157,17 @@ namespace PlaceholderName
 		{
 			return new Callback();
 		}
+
+		/// <summary>
+		/// The render area's width, which may differ from the control's width
+		/// (e.g. with high DPI displays).
+		/// </summary>
+		public int RenderWidth => Handler.RenderWidth;
+		/// <summary>
+		/// The render area's height, which may differ from the control's height
+		/// (e.g. with high DPI displays).
+		/// </summary>
+		public int RenderHeight => Handler.RenderHeight;
 
 		// A depth buffer isn't strictly necessary for this project, which uses
 		// only 2D vertex coordinates, but it's helpful to create one for the
@@ -360,7 +374,7 @@ namespace PlaceholderName
 		{
 			base.OnSizeChanged(e);
 
-			OnResize(new ResizeEventArgs(Width, Height));
+			OnResize(new ResizeEventArgs(RenderWidth, RenderHeight));
 		}
 	}
 }

--- a/src/gui/Eto.Veldrid.Gtk/Eto.Veldrid.Gtk.csproj
+++ b/src/gui/Eto.Veldrid.Gtk/Eto.Veldrid.Gtk.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk2" Version="2.5.0-ci-10199" />
+    <PackageReference Include="Eto.Platform.Gtk2" Version="2.5.0-rc.4" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/gui/Eto.Veldrid.Gtk/Program.cs
+++ b/src/gui/Eto.Veldrid.Gtk/Program.cs
@@ -186,6 +186,11 @@ namespace PlaceholderName
 		public new VeldridSurface.ICallback Callback => (VeldridSurface.ICallback)base.Callback;
 		public new VeldridSurface Widget => (VeldridSurface)base.Widget;
 
+		// TODO: Find out if Gtk2 even supports different DPI settings, and if
+		// so test it out and get this to return the correct values.
+		public int RenderWidth => Widget.Width;
+		public int RenderHeight => Widget.Height;
+
 		public GtkVeldridSurfaceHandler()
 		{
 			Control = new GtkVeldridDrawingArea();
@@ -238,8 +243,8 @@ namespace PlaceholderName
 			Widget.GraphicsDevice = GraphicsDevice.CreateOpenGL(
 				Widget.GraphicsDeviceOptions,
 				platformInfo,
-				(uint)Widget.Width,
-				(uint)Widget.Height);
+				(uint)RenderWidth,
+				(uint)RenderHeight);
 
 			Widget.Swapchain = Widget.GraphicsDevice.MainSwapchain;
 
@@ -260,8 +265,8 @@ namespace PlaceholderName
 			Widget.Swapchain = Widget.GraphicsDevice.ResourceFactory.CreateSwapchain(
 				new SwapchainDescription(
 					source,
-					(uint)Widget.Width,
-					(uint)Widget.Height,
+					(uint)RenderWidth,
+					(uint)RenderHeight,
 					PixelFormat.R32_Float,
 					false));
 

--- a/src/gui/Eto.Veldrid.Mac/Eto.Veldrid.Mac.csproj
+++ b/src/gui/Eto.Veldrid.Mac/Eto.Veldrid.Mac.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-ci-10199" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gui/Eto.Veldrid.Mac/Program.cs
+++ b/src/gui/Eto.Veldrid.Mac/Program.cs
@@ -89,6 +89,11 @@ namespace PlaceholderName
 		public new VeldridSurface.ICallback Callback => (VeldridSurface.ICallback)base.Callback;
 		public new VeldridSurface Widget => (VeldridSurface)base.Widget;
 
+		// TODO: Set up some way to test HiDPI in macOS and figure out how to
+		// get the right values here.
+		public int RenderWidth => Widget.Width;
+		public int RenderHeight => Widget.Height;
+
 		public override NSView ContainerControl => Control;
 
 		public override bool Enabled { get; set; }
@@ -135,8 +140,8 @@ namespace PlaceholderName
 			Widget.GraphicsDevice = GraphicsDevice.CreateOpenGL(
 				Widget.GraphicsDeviceOptions,
 				platformInfo,
-				(uint)Widget.Width,
-				(uint)Widget.Height);
+				(uint)RenderWidth,
+				(uint)RenderHeight);
 
 			Widget.Swapchain = Widget.GraphicsDevice.MainSwapchain;
 
@@ -155,8 +160,8 @@ namespace PlaceholderName
 			Widget.Swapchain = Widget.GraphicsDevice.ResourceFactory.CreateSwapchain(
 				new SwapchainDescription(
 					source,
-					(uint)Widget.Width,
-					(uint)Widget.Height,
+					(uint)RenderWidth,
+					(uint)RenderHeight,
 					PixelFormat.R32_Float,
 					false));
 

--- a/src/gui/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
+++ b/src/gui/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10199" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-rc.4" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/gui/Eto.Veldrid.WinForms/Program.cs
+++ b/src/gui/Eto.Veldrid.WinForms/Program.cs
@@ -63,9 +63,11 @@ namespace PlaceholderName
 
 	public class WinFormsVeldridSurfaceHandler : WindowsControl<WinVeldridUserControl, VeldridSurface, VeldridSurface.ICallback>, VeldridSurface.IHandler
 	{
-
 		public new VeldridSurface.ICallback Callback => (VeldridSurface.ICallback)base.Callback;
 		public new VeldridSurface Widget => (VeldridSurface)base.Widget;
+
+		public int RenderWidth => Control.Width;
+		public int RenderHeight => Control.Height;
 
 		public WinFormsVeldridSurfaceHandler()
 		{
@@ -117,8 +119,8 @@ namespace PlaceholderName
 			Widget.GraphicsDevice = GraphicsDevice.CreateOpenGL(
 				Widget.GraphicsDeviceOptions,
 				platformInfo,
-				(uint)Widget.Width,
-				(uint)Widget.Height);
+				(uint)RenderWidth,
+				(uint)RenderHeight);
 
 			Widget.Swapchain = Widget.GraphicsDevice.MainSwapchain;
 
@@ -139,8 +141,8 @@ namespace PlaceholderName
 			Widget.Swapchain = Widget.GraphicsDevice.ResourceFactory.CreateSwapchain(
 				new SwapchainDescription(
 					source,
-					(uint)Widget.Width,
-					(uint)Widget.Height,
+					(uint)RenderWidth,
+					(uint)RenderHeight,
 					PixelFormat.R32_Float,
 					false));
 

--- a/src/gui/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
+++ b/src/gui/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net472</TargetFramework>
+    <ApplicationManifest>app1.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10199" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-ci-10199" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-rc.4" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-rc.4" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.5.0" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>

--- a/src/gui/Eto.Veldrid.Wpf/Program.cs
+++ b/src/gui/Eto.Veldrid.Wpf/Program.cs
@@ -12,6 +12,9 @@ namespace PlaceholderName
 		public new VeldridSurface.ICallback Callback => (VeldridSurface.ICallback)base.Callback;
 		public new VeldridSurface Widget => (VeldridSurface)base.Widget;
 
+		public int RenderWidth => WinFormsControl.Width;
+		public int RenderHeight => WinFormsControl.Height;
+
 		public WpfVeldridSurfaceHandler() : base(new WinVeldridUserControl())
 		{
 			WinFormsControl.HandleCreated += WinFormsControl_HandleCreated;
@@ -60,8 +63,8 @@ namespace PlaceholderName
 			Widget.GraphicsDevice = GraphicsDevice.CreateOpenGL(
 				Widget.GraphicsDeviceOptions,
 				platformInfo,
-				(uint)Widget.Width,
-				(uint)Widget.Height);
+				(uint)RenderWidth,
+				(uint)RenderHeight);
 
 			Widget.Swapchain = Widget.GraphicsDevice.MainSwapchain;
 
@@ -87,8 +90,8 @@ namespace PlaceholderName
 				Widget.Swapchain = Widget.GraphicsDevice.ResourceFactory.CreateSwapchain(
 					new SwapchainDescription(
 						source,
-						(uint)Widget.Width,
-						(uint)Widget.Height,
+						(uint)RenderWidth,
+						(uint)RenderHeight,
 						PixelFormat.R32_Float,
 						false));
 

--- a/src/gui/Eto.Veldrid.Wpf/app1.manifest
+++ b/src/gui/Eto.Veldrid.Wpf/app1.manifest
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- WPF applications are automatically DPI-aware, but only on the system
+      level (the equivalent of setting dpiAwareness to 'system' or dpiAware to
+      'true'). One of these dpiX tags is necessary to enable other modes. Up to
+      date documentation is nowhere to be found, but here's an older article:
+      https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt846517(v%3Dvs.85) -->
+
+      <!-- dpiAwareness was introduced in Windows 10, version 1607, and allows a
+      list of modes to fall through in descending order of preference. -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+
+      <!-- dpiAware was introduced in Windows Vista, and only allows one mode to
+      be defined. true/PM is a per-monitor mode, while true is system aware. -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
- Add RenderWidth and RenderHeight properties to retrieve actual drawn size in DPI-aware situations
- Add manifest file to set proper default DPI awareness modes (prevents blurriness of other modes)
- Update to Eto 2.5.0 RC4, just to ensure we're testing the latest code

It could also be possible to simply have requests for VeldridSurface.Width or Height return the underlying render width and height, but I wanted to err on the side of caution and specificity. I know having to use Surface.RenderWidth instead of just Surface.Width everywhere is a bit more typing, but I felt it was worth being very explicit when making this new measurement available to users of VeldridSurface. Technically the Width and Height properties are being reported properly by Eto, since they're using device-independent measurements, so a 400x350 control at 125% scaling is still 400x350 device-independent pixels in size, even if it's drawn as 500x438 on screen. If users ask for the control's dimensions, they should get them, I figure. A couple of extra properties lets those of us depending on the actual display pixel dimensions for graphics work get them without too much hassle.

But then I'm no ace API designer, so that decision can certainly be revisited in future as Eto.Veldrid develops.