### PR TITLE
Fix macOS OpenGL and Linux Vulkan

### DIFF
--- a/src/Eto.VeldridSurface/MainForm.cs
+++ b/src/Eto.VeldridSurface/MainForm.cs
@@ -45,7 +45,6 @@ namespace PlaceholderName
 
 			Surface = new VeldridSurface(backend);
 			Surface.VeldridInitialized += (sender, e) => VeldridReady = true;
-			Surface.Draw += (sender, e) => Driver.Draw();
 
 			Content = Surface;
 
@@ -90,6 +89,9 @@ namespace PlaceholderName
 			}
 
 			Driver.SetUpVeldrid();
+
+			Title = $"Veldrid backend: {Surface.Backend.ToString()}";
+
 			Driver.Clock.Start();
 		}
 	}

--- a/src/Eto.VeldridSurface/VeldridDriver.cs
+++ b/src/Eto.VeldridSurface/VeldridDriver.cs
@@ -570,13 +570,7 @@ namespace PlaceholderName
 
 				polyArray = polyList.ToArray();
 
-				PolysVertexBuffer?.Dispose();
-
-				ResourceFactory factory = Surface.GraphicsDevice.ResourceFactory;
-
-				PolysVertexBuffer = factory.CreateBuffer(new BufferDescription((uint)polyArray.Length * VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer));
-
-				Surface.GraphicsDevice.UpdateBuffer(PolysVertexBuffer, 0, polyArray);
+				updateBuffer(ref PolysVertexBuffer, polyArray, VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer);
 
 			}
 			catch (Exception)
@@ -613,13 +607,7 @@ namespace PlaceholderName
 
 				lineArray = lineList.ToArray();
 
-				LinesVertexBuffer?.Dispose();
-
-				ResourceFactory factory = Surface.GraphicsDevice.ResourceFactory;
-
-				LinesVertexBuffer = factory.CreateBuffer(new BufferDescription((uint)lineArray.Length * VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer));
-
-				Surface.GraphicsDevice.UpdateBuffer(LinesVertexBuffer, 0, lineArray);
+				updateBuffer(ref LinesVertexBuffer, lineArray, VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer);
 			}
 			catch (Exception)
 			{
@@ -745,16 +733,8 @@ namespace PlaceholderName
 					}
 				}
 
-				GridVertexBuffer?.Dispose();
-				GridIndexBuffer?.Dispose();
-
-				ResourceFactory factory = Surface.GraphicsDevice.ResourceFactory;
-
-				GridVertexBuffer = factory.CreateBuffer(new BufferDescription((uint)gridArray.Length * VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer));
-				GridIndexBuffer = factory.CreateBuffer(new BufferDescription((uint)gridIndices.Length * sizeof(ushort), BufferUsage.IndexBuffer));
-
-				Surface.GraphicsDevice.UpdateBuffer(GridVertexBuffer, 0, gridArray);
-				Surface.GraphicsDevice.UpdateBuffer(GridIndexBuffer, 0, gridIndices);
+				updateBuffer(ref GridVertexBuffer, gridArray, VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer);
+				updateBuffer(ref GridIndexBuffer, gridIndices, sizeof(ushort), BufferUsage.IndexBuffer);
 			}
 		}
 
@@ -770,27 +750,43 @@ namespace PlaceholderName
 
 				axesIndices = new ushort[4] { 0, 1, 2, 3 };
 
-				AxesVertexBuffer?.Dispose();
-				AxesIndexBuffer?.Dispose();
-
-				ResourceFactory factory = Surface.GraphicsDevice.ResourceFactory;
-
-				AxesVertexBuffer = factory.CreateBuffer(new BufferDescription((uint)axesArray.Length * VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer));
-				AxesIndexBuffer = factory.CreateBuffer(new BufferDescription((uint)axesIndices.Length * sizeof(ushort), BufferUsage.IndexBuffer));
-
-				Surface.GraphicsDevice.UpdateBuffer(AxesVertexBuffer, 0, axesArray);
-				Surface.GraphicsDevice.UpdateBuffer(AxesIndexBuffer, 0, axesIndices);
+				updateBuffer(ref AxesVertexBuffer, axesArray, VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer);
+				updateBuffer(ref AxesIndexBuffer, axesIndices, sizeof(ushort), BufferUsage.IndexBuffer);
 			}
 
 		}
 
+		/// <summary>
+		/// Fills the given buffer with the contents of 'data', creating or
+		/// resizing it as necessary.
+		/// </summary>
+		/// <param name="buffer">The Veldrid.DeviceBuffer to fill.</param>
+		/// <param name="data">The array of elements to put in the buffer.</param>
+		/// <param name="elementSize">The size in bytes of each element.</param>
+		/// <param name="usage">The Veldrid.BufferUsage type of 'buffer'.</param>
+		public void updateBuffer<T>(ref DeviceBuffer buffer, T[] data, uint elementSize, BufferUsage usage)
+			where T : struct
+		{
+			buffer?.Dispose();
+
+			ResourceFactory factory = Surface.GraphicsDevice.ResourceFactory;
+
+			buffer = factory.CreateBuffer(new BufferDescription(elementSize * (uint)data.Length, usage));
+
+			Surface.GraphicsDevice.UpdateBuffer(buffer, 0, data);
+		}
+
 		public void updateViewport()
 		{
+			if (!Surface.ControlReady)
+			{
+				return;
+			}
+
 			drawAxes();
 			drawGrid();
 			drawLines();
 			drawPolygons();
-			Draw();
 		}
 
 		public void Draw()
@@ -799,6 +795,8 @@ namespace PlaceholderName
 			{
 				return;
 			}
+
+			updateViewport();
 
 			CommandList.Begin();
 

--- a/src/Eto.VeldridSurface/VeldridSurface.cs
+++ b/src/Eto.VeldridSurface/VeldridSurface.cs
@@ -123,23 +123,28 @@ namespace PlaceholderName
 
 		public new interface ICallback : Control.ICallback
 		{
-			void InitializeOpenGL(VeldridSurface s);
-
+			void OnControlReady(VeldridSurface s, EventArgs e);
 			void OnDraw(VeldridSurface s, EventArgs e);
+			void OnOpenGLReady(VeldridSurface s, EventArgs e);
 			void OnResize(VeldridSurface s, ResizeEventArgs e);
 			void OnVeldridInitialized(VeldridSurface s, EventArgs e);
 		}
 
 		protected new class Callback : Control.Callback, ICallback
 		{
-			public void InitializeOpenGL(VeldridSurface s)
+			public void OnControlReady(VeldridSurface s, EventArgs e)
 			{
-				s.GLReady = true;
+				s.ControlReady = true;
 			}
 
 			public void OnDraw(VeldridSurface s, EventArgs e)
 			{
 				s.OnDraw(e);
+			}
+
+			public void OnOpenGLReady(VeldridSurface s, EventArgs e)
+			{
+				s.OpenGLReady = true;
 			}
 
 			public void OnResize(VeldridSurface s, ResizeEventArgs e)
@@ -239,18 +244,6 @@ namespace PlaceholderName
 		public GraphicsDevice GraphicsDevice { get; set; }
 		public Swapchain Swapchain { get; set; }
 
-		private bool? _glReady = null;
-		public bool? GLReady
-		{
-			get { return _glReady; }
-			private set
-			{
-				_glReady = value;
-
-				InitializeGraphicsApi();
-			}
-		}
-
 		private bool _controlReady = false;
 		public bool ControlReady
 		{
@@ -258,6 +251,18 @@ namespace PlaceholderName
 			private set
 			{
 				_controlReady = value;
+
+				InitializeGraphicsApi();
+			}
+		}
+
+		private bool? _openGLReady = null;
+		public bool? OpenGLReady
+		{
+			get { return _openGLReady; }
+			private set
+			{
+				_openGLReady = value;
 
 				InitializeGraphicsApi();
 			}
@@ -292,10 +297,8 @@ namespace PlaceholderName
 
 			if (Backend == GraphicsBackend.OpenGL)
 			{
-				GLReady = false;
+				OpenGLReady = false;
 			}
-
-			LoadComplete += (sender, e) => ControlReady = true;
 		}
 
 		public void InitializeGraphicsApi()
@@ -305,7 +308,7 @@ namespace PlaceholderName
 				return;
 			}
 
-			switch (GLReady)
+			switch (OpenGLReady)
 			{
 				case false:
 					return;

--- a/src/gui/Eto.Veldrid.Gtk/Program.cs
+++ b/src/gui/Eto.Veldrid.Gtk/Program.cs
@@ -172,6 +172,7 @@ namespace PlaceholderName
 			X11Interop.XFree(visualInfo);
 
 			Context = new GraphicsContext(Mode, WindowInfo, 3, 3, GraphicsContextFlags.ForwardCompatible);
+
 			Context.MakeCurrent(WindowInfo);
 		}
 
@@ -217,10 +218,12 @@ namespace PlaceholderName
 			{
 				Control.CreateOpenGLContext();
 
-				Callback.InitializeOpenGL(Widget);
-
-				Control.ExposeEvent -= Control_ExposeEvent;
+				Callback.OnOpenGLReady(Widget, EventArgs.Empty);
 			}
+
+			Control.ExposeEvent -= Control_ExposeEvent;
+
+			Callback.OnControlReady(Widget, EventArgs.Empty);
 		}
 
 		/// <summary>
@@ -259,8 +262,8 @@ namespace PlaceholderName
 			//   https://github.com/mellinoe/veldrid/issues/155
 			//
 			var source = SwapchainSource.CreateXlib(
-				Control.Display.Handle,
-				Control.GdkWindow.Handle);
+				X11Interop.gdk_x11_display_get_xdisplay(Control.Display.Handle),
+				X11Interop.gdk_x11_drawable_get_xid(Control.GdkWindow.Handle));
 
 			Widget.Swapchain = Widget.GraphicsDevice.ResourceFactory.CreateSwapchain(
 				new SwapchainDescription(

--- a/src/gui/Eto.Veldrid.Mac/Program.cs
+++ b/src/gui/Eto.Veldrid.Mac/Program.cs
@@ -46,6 +46,8 @@ namespace PlaceholderName
 			WindowInfo = Utilities.CreateMacOSWindowInfo(Window.Handle, Handle);
 
 			Context = new GraphicsContext(Mode, WindowInfo, 3, 3, GraphicsContextFlags.ForwardCompatible);
+
+			Context.MakeCurrent(WindowInfo);
 		}
 
 		public void MakeCurrent(IntPtr context)
@@ -69,15 +71,6 @@ namespace PlaceholderName
 
 		public override void DrawRect(CGRect dirtyRect)
 		{
-			if (Context == null)
-			{
-				CreateOpenGLContext();
-
-				Context.MakeCurrent(WindowInfo);
-
-				OpenGLContextCreated?.Invoke(this, EventArgs.Empty);
-			}
-
 			Draw?.Invoke(this, EventArgs.Empty);
 		}
 	}
@@ -100,7 +93,7 @@ namespace PlaceholderName
 		{
 			Control = new MacVeldridView();
 
-			Control.OpenGLContextCreated += Control_OpenGLContextCreated;
+			Control.Draw += Control_Draw;
 		}
 
 		public override void AttachEvent(string id)
@@ -116,9 +109,18 @@ namespace PlaceholderName
 			}
 		}
 
-		private void Control_OpenGLContextCreated(object sender, EventArgs e)
+		private void Control_Draw(object sender, EventArgs e)
 		{
-			Callback.InitializeOpenGL(Widget);
+			if (Widget.Backend == GraphicsBackend.OpenGL)
+			{
+				Control.CreateOpenGLContext();
+
+				Callback.OnOpenGLReady(Widget, EventArgs.Empty);
+			}
+
+			Control.Draw -= Control_Draw;
+
+			Callback.OnControlReady(Widget, EventArgs.Empty);
 		}
 
 		public void InitializeOpenGL()

--- a/src/gui/Eto.Veldrid.Mac/Program.cs
+++ b/src/gui/Eto.Veldrid.Mac/Program.cs
@@ -64,6 +64,11 @@ namespace PlaceholderName
 		{
 			base.DidChangeBackingProperties();
 
+			UpdateContext();
+		}
+
+		public override void DrawRect(CGRect dirtyRect)
+		{
 			if (Context == null)
 			{
 				CreateOpenGLContext();
@@ -72,14 +77,7 @@ namespace PlaceholderName
 
 				OpenGLContextCreated?.Invoke(this, EventArgs.Empty);
 			}
-			else
-			{
-				UpdateContext();
-			}
-		}
 
-		public override void DrawRect(CGRect dirtyRect)
-		{
 			Draw?.Invoke(this, EventArgs.Empty);
 		}
 	}

--- a/src/gui/Eto.Veldrid.WinForms/Program.cs
+++ b/src/gui/Eto.Veldrid.WinForms/Program.cs
@@ -95,8 +95,10 @@ namespace PlaceholderName
 			{
 				Control.CreateOpenGLContext();
 
-				Callback.InitializeOpenGL(Widget);
+				Callback.OnOpenGLReady(Widget, EventArgs.Empty);
 			}
+
+			Callback.OnControlReady(Widget, EventArgs.Empty);
 		}
 
 		/// <summary>

--- a/src/gui/Eto.Veldrid.Wpf/Program.cs
+++ b/src/gui/Eto.Veldrid.Wpf/Program.cs
@@ -39,8 +39,10 @@ namespace PlaceholderName
 			{
 				WinFormsControl.CreateOpenGLContext();
 
-				Callback.InitializeOpenGL(Widget);
+				Callback.OnOpenGLReady(Widget, EventArgs.Empty);
 			}
+
+			Callback.OnControlReady(Widget, EventArgs.Empty);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Okay, got things sorted!

- The blank screen I'd seen on my non-Metal Mac was a side effect of initializing too early. Now we only do it on the first draw call, and things seem to work out more reliably.

The Vulkan problem is fourfold:
- The exception about libvulkan.so is a Veldrid issue, specifically a check in its native library loader [that mistakes Linux Mint 19 for Android](https://github.com/mellinoe/vk/issues/24). I gather a fix is forthcoming, and once that check is spruced up it should find the right .so and load it.
  - The workaround for this is to use symlinks, as we've been doing.
- Along with that, there's another use of the same sort of check in the Veldrid library itself, mistaking Mint for Android when determining whether the Vulkan backend is supported.
  - Until this gets fixed, just keep forcing the backend to Vulkan when necessary for testing.
- A major problem in my code was using Gdk handles instead of actual X11 handles when creating the swapchain source during API initialization. Without the means to test anything but OpenGL in Linux for the longest time I hadn't realized what I was doing. That's been taken care of, very simple as I already had the native P/Invoke stuff available.
- The final problem was in the flaky buffer update logic I foisted on you way back when. I've factored it all out to a helper method (updateBuffer) that gets called when necessary, including at the beginning of a Draw call. The call to Draw at the end of your updateViewport method was removed out of necessity, but I believe things still work thanks to the buffers updating on every Draw.