### PR TITLE
Fix Mac .app Release builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,10 +35,16 @@
     <VeldridSpirvNativeName>libveldrid-spirv.dylib</VeldridSpirvNativeName>
   </PropertyGroup>
 
-  <Target Name="SetNeatenizePath" AfterTargets="Build" BeforeTargets="CopyVeldridSpirvNative">
+  <Target Name="SetPaths" AfterTargets="Build" BeforeTargets="CopyVeldridSpirvNative">
     <PropertyGroup>
-      <NeatenizePath Condition="$(IsMacProject) AND $(OutputAppPath) != ''">$(OutputAppPath)\Contents\MonoBundle\</NeatenizePath>
-      <NeatenizePath Condition="!$(IsMacProject) OR $(OutputAppPath) == ''">$(OutputPath)</NeatenizePath>
+      <UsingMacAppBundle>false</UsingMacAppBundle>
+      <UsingMacAppBundle Condition="$(IsMacProject) AND $(OutputAppPath) != ''">true</UsingMacAppBundle>
+
+      <VeldridSpirvNativePath>$(OutputPath)</VeldridSpirvNativePath>
+      <VeldridSpirvNativePath Condition="$(UsingMacAppBundle)">$(OutputAppPath)\Contents\Libraries</VeldridSpirvNativePath>
+
+      <NeatenizePath>$(OutputPath)</NeatenizePath>
+      <NeatenizePath Condition="$(UsingMacAppBundle) AND !$(MacBundleMono)">$(OutputAppPath)\Contents\MonoBundle\</NeatenizePath>
     </PropertyGroup>
   </Target>
 
@@ -46,10 +52,10 @@
     <NoCopyVeldridSpirvNative>Eto.VeldridSurface</NoCopyVeldridSpirvNative>
   </PropertyGroup>
 
-  <Target Name="CopyVeldridSpirvNative" AfterTargets="SetNeatenizePath" BeforeTargets="NeatenizeLibraries" Condition="!$(NoCopyVeldridSpirvNative.Contains($(MSBuildProjectName)))">
+  <Target Name="CopyVeldridSpirvNative" AfterTargets="SetPaths" BeforeTargets="NeatenizeLibraries" Condition="!$(NoCopyVeldridSpirvNative.Contains($(MSBuildProjectName)))">
     <Copy
       SourceFiles="$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))veldrid.spirv\$(VeldridSpirvVersion)\runtimes\$(RuntimeID)\native\$(VeldridSpirvNativeName)"
-      DestinationFolder="$(NeatenizePath)" />
+      DestinationFolder="$(VeldridSpirvNativePath)" />
   </Target>
 
   <PropertyGroup>
@@ -75,7 +81,7 @@
     <ItemGroup>
       <Shaders Include="$(TopLevelDirectory)src\shaders\**\*" />
     </ItemGroup>
-    <Copy Condition="$(OutputAppPath) != ''" SourceFiles="@(Shaders)" DestinationFolder="$(OutputAppPath)\Contents\MonoBundle\shaders\%(Shaders.RecursiveDir)" />
+    <Copy Condition="$(OutputAppPath) != ''" SourceFiles="@(Shaders)" DestinationFolder="$(OutputAppPath)\Contents\Resources\shaders\%(Shaders.RecursiveDir)" />
     <Copy Condition="$(OutputAppPath) == ''" SourceFiles="@(Shaders)" DestinationFolder="$(OutputPath)\shaders\%(Shaders.RecursiveDir)" />
   </Target>
 

--- a/src/Eto.VeldridSurface/MainForm.cs
+++ b/src/Eto.VeldridSurface/MainForm.cs
@@ -38,7 +38,10 @@ namespace PlaceholderName
 			}
 		}
 
-		public MainForm(GraphicsBackend backend)
+		public MainForm(GraphicsBackend backend) : this(backend, AppContext.BaseDirectory, "shaders")
+		{
+		}
+		public MainForm(GraphicsBackend backend, string executableDirectory, string shaderSubdirectory)
 		{
 			InitializeComponent();
 
@@ -79,7 +82,12 @@ namespace PlaceholderName
 			ovpSettings.addPolygon(testPoly, Color.FromArgb(255, 0, 0), 1.0f, false);
 
 
-			Driver = new VeldridDriver(ref ovpSettings, ref Surface);
+			Driver = new VeldridDriver(ref ovpSettings, ref Surface)
+			{
+				Surface = Surface,
+				ExecutableDirectory = executableDirectory,
+				ShaderSubdirectory = shaderSubdirectory
+			};
 		}
 
 		ContextMenu vp_menu;

--- a/src/Eto.VeldridSurface/VeldridDriver.cs
+++ b/src/Eto.VeldridSurface/VeldridDriver.cs
@@ -35,6 +35,9 @@ namespace PlaceholderName
 	/// </remarks>
 	public class VeldridDriver
 	{
+		public string ExecutableDirectory { get; set; }
+		public string ShaderSubdirectory { get; set; }
+
 		public VeldridSurface Surface;
 
 		public UITimer Clock = new UITimer();
@@ -1017,7 +1020,7 @@ namespace PlaceholderName
 				default:
 					break;
 			}
-				
+
 			var vertex = new ShaderDescription(ShaderStages.Vertex, vertexShaderSpirvBytes, "main", true);
 			var fragment = new ShaderDescription(ShaderStages.Fragment, fragmentShaderSpirvBytes, "main", true);
 			Shader[] shaders = factory.CreateFromSpirv(vertex, fragment, options);
@@ -1113,9 +1116,8 @@ namespace PlaceholderName
 		{
 			byte[] bytes;
 
-			string shaderDir = Path.Combine(AppContext.BaseDirectory, "shaders");
 			string name = $"VertexColor-{stage.ToString().ToLower()}.450.glsl";
-			string full = Path.Combine(shaderDir, name);
+			string full = Path.Combine(ExecutableDirectory, ShaderSubdirectory, name);
 
 			// Precompiled SPIR-V bytecode can speed up program start by saving
 			// the need to load text files and compile them before converting

--- a/src/gui/Eto.Veldrid.Mac/Program.cs
+++ b/src/gui/Eto.Veldrid.Mac/Program.cs
@@ -4,6 +4,8 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Platform;
 using System;
+using System.Diagnostics;
+using System.IO;
 using Veldrid;
 using Veldrid.OpenGL;
 
@@ -184,7 +186,16 @@ namespace PlaceholderName
 			var platform = new Eto.Mac.Platform();
 			platform.Add<VeldridSurface.IHandler>(() => new MacVeldridSurfaceHandler());
 
-			new Application(platform).Run(new MainForm(backend));
+			// AppContext.BaseDirectory is too simple for the case of the Mac
+			// projects. When building an app bundle that depends on the Mono
+			// framework being installed, it properly returns the path of the
+			// executable in Eto.Veldrid.app/Contents/MacOS. When building an
+			// app bundle that instead bundles Mono by way of mkbundle, on the
+			// other hand, it returns the directory containing the .app.
+			new Application(platform).Run(new MainForm(
+				backend,
+				Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName),
+				Path.Combine("..", "Resources", "shaders")));
 		}
 	}
 }


### PR DESCRIPTION
Okay, first things first: please don't take this the wrong way, but I think I made a mistake accepting pull requests on my fork/philstopford/master branch. I don't mean anything personal by it, but I feel like for the sake of clean PRs on your forked repo, I should just keep that branch in sync by hand from now on. I wish I'd realized it sooner, but a few minutes ago I tried to open a PR and found Github thought it needed to include **27** commits, 26 of which were unnecessary since they'd already been incorporated into your fork. I'd like to think Github would be smart enough to skip applying commits once it realized they'd be empty, but I don't want to take that chance and leave you with a jacked up repository you have to clean up should things go pear shaped.

I've now force-pushed an updated version of that branch to my repo (sorry if you were using it), which matches the commit history of your fork's master branch. From now on, if it's alright with you, I'd like to just do a `git pull` from your fork into my branch whenever I want to make a contribution. I'll keep an eye on your work, and any time I feel the need to offer anything I'll pull, rebase my changes if necessary, and go from there.

I've heard it said that "Git means never having to say 'you should have'", and I've found it's mostly true, but when you have a branch of a fork of a repo, things start getting into chicken or the egg rather quickly. If you want to open an issue in my repository for ongoing discussion of changes you're making, feel free! You could easily ping me if you needed my input on any updates, and I'd just pull down the new code without getting out of sync with your fork.

But onto the good news! I'm happy to report I solved a problem I'd been having with my own project, and that caught up with us here, where mkbundle builds in macOS would fail in ways I simply didn't have the patience to solve until now.

If mkbundle is installed on the build machine, the Release builds in Eto Mac .app projects [use it by default](https://github.com/picoe/Eto/blob/9ba80297abb1b4cce8d544f13ccf3d212c2a3375/build/MacTemplate/MacTemplate.targets#L34), and in my own code I'd been skirting the issue by disabling that, but when I noticed this project's Release configuration would fail to run in macOS, I spent some time figuring out what to do about it. By copying Veldrid.SPIRV's native support library into the right place (.app bundles have a "Libraries" folder for this sort of thing), it can be found by the executable, and everything's hunky-dory.

I've also moved the shaders to the Resources directory, which makes more sense and is always there even when there's no MonoBundle directory. Incidentally that is a strangely unintuitive name, what with that folder only being created if you DON'T bundle mono; I know what they mean by it but it does look odd at a glance.