### PR TITLE
Take DPI scaling into account when panning

### DIFF
--- a/src/Eto.Veldrid/VeldridSurface.cs
+++ b/src/Eto.Veldrid/VeldridSurface.cs
@@ -61,6 +61,7 @@ namespace Eto.Veldrid
 		/// (e.g. with high DPI displays).
 		/// </summary>
 		public int RenderHeight => Handler.RenderHeight;
+		public float DpiFactor { get; protected set; }
 
 		public GraphicsContext OpenTKGraphicsContext { get; protected set; }
 		public GraphicsMode OpenTKGraphicsMode { get; } = new GraphicsMode(
@@ -104,6 +105,7 @@ namespace Eto.Veldrid
 		}
 		public VeldridSurface(GraphicsBackend backend, GraphicsDeviceOptions options)
 		{
+			DpiFactor = (float)RenderWidth / (float)Width;
 			Backend = backend;
 			GraphicsDeviceOptions = options;
 		}
@@ -234,6 +236,8 @@ namespace Eto.Veldrid
 			{
 				Swapchain.Resize((uint)e.Width, (uint)e.Height);
 			}
+
+			DpiFactor = (float)RenderWidth / (float)Width;
 
 			Properties.TriggerEvent(ResizeEvent, this, e);
 		}

--- a/test/TestEtoVeldrid/VeldridDriver.cs
+++ b/test/TestEtoVeldrid/VeldridDriver.cs
@@ -265,8 +265,7 @@ namespace VeldridEto
 			}
 			if (e.Buttons == MouseButtons.Primary)
 			{
-				float dpiFactor = (float)Surface.RenderWidth / (float)Surface.Width;
-				PointF scaledLocation = e.Location * dpiFactor;
+				PointF scaledLocation = e.Location * Surface.DpiFactor;
 
 				if (!dragging)
 				{

--- a/test/TestEtoVeldrid/VeldridDriver.cs
+++ b/test/TestEtoVeldrid/VeldridDriver.cs
@@ -265,19 +265,22 @@ namespace VeldridEto
 			}
 			if (e.Buttons == MouseButtons.Primary)
 			{
+				float dpiFactor = (float)Surface.RenderWidth / (float)Surface.Width;
+				PointF scaledLocation = e.Location * dpiFactor;
+
 				if (!dragging)
 				{
-					setDown(e.Location.X, e.Location.Y);
+					setDown(scaledLocation.X, scaledLocation.Y);
 				}
 				object locking = new object();
 				lock (locking)
 				{
-					float new_X = (ovpSettings.cameraPosition.X - ((e.Location.X - x_orig) * ovpSettings.zoomFactor * ovpSettings.base_zoom));
-					float new_Y = (ovpSettings.cameraPosition.Y + ((e.Location.Y - y_orig) * ovpSettings.zoomFactor * ovpSettings.base_zoom));
+					float new_X = (ovpSettings.cameraPosition.X - ((scaledLocation.X - x_orig) * ovpSettings.zoomFactor * ovpSettings.base_zoom));
+					float new_Y = (ovpSettings.cameraPosition.Y + ((scaledLocation.Y - y_orig) * ovpSettings.zoomFactor * ovpSettings.base_zoom));
 					ovpSettings.cameraPosition = new PointF(new_X, new_Y);
 					ovpSettings.changed = true;
-					x_orig = e.Location.X;
-					y_orig = e.Location.Y;
+					x_orig = scaledLocation.X;
+					y_orig = scaledLocation.Y;
 				}
 			}
 			updateViewport();


### PR DESCRIPTION
Whether dpiFactor is something I should eventually roll into the VeldridSurface control itself, I can't yet say, but for the short term this lets viewport panning stay properly locked to the mouse as you drag. I'm not actually sure how one's meant to correctly deal with different DPI in an Eto app with regard to things like mouse events, but for the immediate purpose of your test application I think this works well enough.