### PR TITLE
Fixes for Windows Desktop SDK and .NET Core 3.1

### DIFF
--- a/Eto.Veldrid.sln
+++ b/Eto.Veldrid.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6136B651-45C5-48C7-80E7-943FF2461732}"

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="myget-eto" value="https://www.myget.org/F/eto/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
+++ b/src/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,10 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10403" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
 </Project>

--- a/src/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
+++ b/src/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,20 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10403" />
     <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-ci-10403" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.7.0" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="ReachFramework" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
 
 </Project>

--- a/test/TestEtoVeldrid.WinForms/TestEtoVeldrid.WinForms.csproj
+++ b/test/TestEtoVeldrid.WinForms/TestEtoVeldrid.WinForms.csproj
@@ -1,8 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,10 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10403" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
 </Project>

--- a/test/TestEtoVeldrid.Wpf/TestEtoVeldrid.Wpf.csproj
+++ b/test/TestEtoVeldrid.Wpf/TestEtoVeldrid.Wpf.csproj
@@ -1,31 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationManifest>app1.manifest</ApplicationManifest>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Eto.Veldrid.WinForms\Eto.Veldrid.WinForms.csproj" />
     <ProjectReference Include="..\..\src\Eto.Veldrid.Wpf\Eto.Veldrid.Wpf.csproj" />
     <ProjectReference Include="..\TestEtoVeldrid\TestEtoVeldrid.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-ci-10403" />
     <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-ci-10403" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="ReachFramework" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@philstopford I updated the project files. Note: for .NET Core projects we generally do not use the `Reference` tags at all. Instead you use either `PackageReference`, `ProjectReference` or `FrameworkReference`.

However, when targeting Windows Desktop APIs (like WinForms and WPF), you actually target a different .NET Core Framework reference. Usually, by using `<Project Sdk="Microsoft.NET.Sdk">` and a .NET Core TFM, the Sdk implicitly adds a `FrameworkReference` to `Microsoft.NETCore.App`. You can see that in Visual Studio if you expand the `Dependencies` &rightarrow; `Frameworks` node in the Solution Explorer.

Previously we used to `Reference` the `System.Windows.Forms` library (and others) when targeting .NET Framework. Those were generally references to libraries in the GAC. Of course we still target the Windows Forms SDK, but we do that by including a `FrameworkReference` to `Microsoft.WindowsDesktop.App`. But that is implicitly taken care of for us by using the Sdk reference on the project `<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">`.

BTW, the Frameworks used by the `FrameworkReference` tags, are actually side-by-side 'mini'-GACs. For .NET Core you'll find these in the `C:\Program Files\dotnet\shared` folder. There you can also find the ASP.NET Core frameworks that the Web SDK uses when you specify `<Project Sdk="Microsoft.NET.Sdk.Web">`